### PR TITLE
Poll characteristics for value each N seconds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ your array (list) of enabled platform plugins. Example config:
     "email": "your@email.com",
     "password": "yourT0p5ecre7Passw0rd",
     "alarmCode": "0000",
-    "doorCode": "000000"
+    "doorCode": "000000",
+    "pollInterval": 60
   }
 ]
 ```
@@ -47,3 +48,4 @@ your array (list) of enabled platform plugins. Example config:
 * __`password`__ Required string containing your Verisure account password.
 * `alarmCode` Optional string containing your security system alarm code.
 * `doorCode` Optional string containing your door lock code.
+* `pollInterval` Optional integer containing poll interval in seconds. Defaults to `60`.

--- a/accessories/alarm.js
+++ b/accessories/alarm.js
@@ -79,7 +79,7 @@ class Alarm extends VerisureAccessory {
     const { Service, Characteristic } = this.homebridge.hap;
 
     this.service = new Service.SecuritySystem(this.name);
-    this.service
+    const currentStateCharacteristic = this.service
       .getCharacteristic(Characteristic.SecuritySystemCurrentState)
       .on('get', this.getCurrentAlarmState.bind(this));
 
@@ -90,7 +90,7 @@ class Alarm extends VerisureAccessory {
 
     this.accessoryInformation.setCharacteristic(Characteristic.Model, this.model);
 
-    // TODO: Init polling for externally invoked state changes.
+    this.pollCharacteristics.push(currentStateCharacteristic);
 
     return [this.accessoryInformation, this.service];
   }

--- a/accessories/doorlock.js
+++ b/accessories/doorlock.js
@@ -4,8 +4,7 @@ class DoorLock extends VerisureAccessory {
   constructor(...args) {
     super(...args);
 
-    const { doorcode, doorCode } = this.platformConfig;
-    this.doorCode = doorcode || doorCode;
+    this.doorCode = this.platformConfig.doorCode;
     this.name = VerisureAccessory.getUniqueAccessoryName(`SmartLock (${this.config.area})`);
   }
 
@@ -67,9 +66,7 @@ class DoorLock extends VerisureAccessory {
     const request = {
       method: 'PUT',
       uri: `/device/${this.serialNumber}/${value ? 'lock' : 'unlock'}`,
-      json: {
-        code: this.doorCode,
-      },
+      json: { code: this.doorCode },
     };
 
     this.installation.client(request)
@@ -97,7 +94,7 @@ class DoorLock extends VerisureAccessory {
     const { Service, Characteristic } = this.homebridge.hap;
 
     this.service = new Service.LockMechanism(this.name);
-    this.service
+    const currentStateCharacteristic = this.service
       .getCharacteristic(Characteristic.LockCurrentState)
       .on('get', this.getCurrentLockState.bind(this));
 
@@ -106,7 +103,7 @@ class DoorLock extends VerisureAccessory {
       .on('get', this.getTargetLockState.bind(this))
       .on('set', this.setTargetLockState.bind(this));
 
-    // TODO: Init polling for externally invoked state changes.
+    this.pollCharacteristics.push(currentStateCharacteristic);
 
     return [this.accessoryInformation, this.service];
   }

--- a/accessories/verisure.js
+++ b/accessories/verisure.js
@@ -12,6 +12,7 @@ class VerisureAccessory {
 
     this.value = null;
     this.service = null;
+    this.pollCharacteristics = [];
 
     const { Characteristic, Service } = homebridge.hap;
 
@@ -19,6 +20,12 @@ class VerisureAccessory {
     this.accessoryInformation
       .setCharacteristic(Characteristic.Manufacturer, 'Verisure')
       .setCharacteristic(Characteristic.SerialNumber, this.serialNumber);
+
+    if (platformConfig && platformConfig.pollInterval) {
+      setInterval(() => {
+        this.pollCharacteristics.forEach(characteristic => characteristic.getValue());
+      }, platformConfig.pollInterval * 1000);
+    }
   }
 
   static getUniqueAccessoryName(name) {

--- a/platform.js
+++ b/platform.js
@@ -10,11 +10,25 @@ class VerisurePlatform {
       throw Error('Module not initiated.');
     }
 
-    this.config = config;
+    const {
+      alarmCode,
+      doorcode, doorCode,
+      email,
+      password,
+      pollInterval = 60,
+    } = config;
+    this.config = {
+      alarmCode,
+      doorCode: doorcode || doorCode,
+      email,
+      password,
+      pollInterval,
+    };
+
     this.homebridge = homebridge;
     this.logger = logger;
 
-    this.verisure = new Verisure(this.config.email, config.password);
+    this.verisure = new Verisure(email, password);
   }
 
   static init(homebridgeRef) {

--- a/platform.test.js
+++ b/platform.test.js
@@ -11,10 +11,36 @@ describe('Platform', () => {
 
   it('module exposes a platform class', () => {
     VerisurePlatform.init('homebridge');
-    const platform = new VerisurePlatform('logger', 'config');
+    const platform = new VerisurePlatform('logger', {});
     expect(platform).toBeInstanceOf(VerisurePlatform);
-    expect(platform.config).toBe('config');
+    expect(platform.config).toMatchObject({
+      pollInterval: 60,
+    });
     expect(platform.logger).toBe('logger');
+  });
+
+  it('platform builds config with defaults', () => {
+    const platform = new VerisurePlatform(null, {
+      alarmCode: '2345',
+      doorcode: '1234', // deprecated door code config key
+    });
+    expect(platform.config).toMatchObject({
+      alarmCode: '2345',
+      doorCode: '1234', // resolves to camel case 👍
+      pollInterval: 60,
+    });
+  });
+
+  it('platform builds config with passed values', () => {
+    const config = {
+      email: 'foo@bar.com',
+      password: 't0ps3cret',
+      alarmCode: '2345',
+      doorCode: '1234',
+      pollInterval: 120,
+    };
+    const platform = new VerisurePlatform(null, config);
+    expect(platform.config).toMatchObject(config);
   });
 
   it('transform empty overview into empty lists of device configs', () => {


### PR DESCRIPTION
Introducing poll functionality for alarm and door lock accessories. This will push accessory states to devices when state is altered externally, eg. from outside homebridge.

> Alarm (Strandvägen) i Förvalt rum är avaktiverat.

No need to update your config, will poll every minute by default.

__Fixes:__ #22 