### PR TITLE
Enable configuration using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,12 @@ your array (list) of enabled platform plugins. Example config:
 * `alarmCode` Optional string containing your security system alarm code.
 * `doorCode` Optional string containing your door lock code.
 * `pollInterval` Optional integer containing poll interval in seconds. Defaults to `60`.
+
+### Environment variables
+
+For convenience, the following environment variables can be used instead of placing secrets in your `config.json`.
+
+* `VERISURE_ALARM_CODE`
+* `VERISURE_DOOR_CODE`
+* `VERISURE_EMAIL`
+* `VERISURE_PASSWORD`

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -11,24 +11,32 @@ class VerisurePlatform {
     }
 
     const {
+      VERISURE_ALARM_CODE,
+      VERISURE_DOOR_CODE,
+      VERISURE_EMAIL,
+      VERISURE_PASSWORD,
+    } = process.env;
+
+    const {
       alarmCode,
       doorcode, doorCode,
       email,
       password,
       pollInterval = 60,
     } = config;
+
     this.config = {
-      alarmCode,
-      doorCode: doorcode || doorCode,
-      email,
-      password,
+      alarmCode: VERISURE_ALARM_CODE || alarmCode,
+      doorCode: VERISURE_DOOR_CODE || doorcode || doorCode,
+      email: VERISURE_EMAIL || email,
+      password: VERISURE_PASSWORD || password,
       pollInterval,
     };
 
     this.homebridge = homebridge;
     this.logger = logger;
 
-    this.verisure = new Verisure(email, password);
+    this.verisure = new Verisure(this.config.email, this.config.password);
   }
 
   static init(homebridgeRef) {

--- a/lib/platform.test.js
+++ b/lib/platform.test.js
@@ -33,14 +33,39 @@ describe('Platform', () => {
 
   it('platform builds config with passed values', () => {
     const config = {
-      email: 'foo@bar.com',
-      password: 't0ps3cret',
       alarmCode: '2345',
       doorCode: '1234',
+      email: 'foo@bar.com',
+      password: 't0ps3cret',
       pollInterval: 120,
     };
     const platform = new VerisurePlatform(null, config);
     expect(platform.config).toMatchObject(config);
+  });
+
+  it('platform builds config with environment variables', () => {
+    const envVars = {
+      VERISURE_ALARM_CODE: '2345',
+      VERISURE_DOOR_CODE: '1234',
+      VERISURE_EMAIL: 'foo@bar.com',
+      VERISURE_PASSWORD: 't0ps3cret',
+    };
+
+    const envKeys = Object.keys(envVars);
+
+    envKeys.forEach((key) => { process.env[key] = envVars[key]; });
+
+    const config = {
+      alarmCode: envVars.VERISURE_ALARM_CODE,
+      doorCode: envVars.VERISURE_DOOR_CODE,
+      email: envVars.VERISURE_EMAIL,
+      password: envVars.VERISURE_PASSWORD,
+    };
+
+    const platform = new VerisurePlatform(null, {});
+    expect(platform.config).toMatchObject(config);
+
+    envKeys.forEach((key) => { process.env[key] = null; });
   });
 
   it('transform empty overview into empty lists of device configs', () => {


### PR DESCRIPTION
In some setups, configuring the platform using environment variables would be really convenient.

__Update the plugin globally__

```bash
$ npm install -g git://github.com/ptz0n/homebridge-verisure#config-environment-variables
```

__Alt. run it manually__

```bash
$ git clone https://github.com/ptz0n/homebridge-verisure.git
$ cd homebridge-verisure
$ git checkout config-environment-variables
$ npm install
$ homebridge -P .
```

Fixes: #47 