### PR TITLE
Decrease log level when polling

### DIFF
--- a/lib/accessories/alarm.js
+++ b/lib/accessories/alarm.js
@@ -38,7 +38,7 @@ class Alarm extends VerisureAccessory {
   }
 
   getCurrentAlarmState(callback) {
-    this.log('Getting current alarm state.');
+    this.log('Getting current alarm state.', 'debug');
 
     this.installation.getOverview()
       .then((overview) => {

--- a/lib/accessories/alarm.test.js
+++ b/lib/accessories/alarm.test.js
@@ -4,7 +4,7 @@ const Alarm = require('./alarm');
 
 describe('Alarm', () => {
   const homebridge = { hap };
-  const logger = jest.fn();
+  const logger = { info: jest.fn(), debug: jest.fn() };
   const config = {
     statusType: 'DISARMED',
   };

--- a/lib/accessories/climatesensor.test.js
+++ b/lib/accessories/climatesensor.test.js
@@ -4,7 +4,7 @@ const ClimateSensor = require('./climatesensor');
 
 describe('ClimateSensor', () => {
   const homebridge = { hap };
-  const logger = jest.fn();
+  const logger = { info: jest.fn() };
   const config = {
     deviceArea: 'Hallway',
     deviceLabel: 'asd123',

--- a/lib/accessories/contactsensor.js
+++ b/lib/accessories/contactsensor.js
@@ -15,7 +15,7 @@ class ContactSensor extends VerisureAccessory {
   }
 
   getCurrentSensorState(callback) {
-    this.log('Getting current sensor state.');
+    this.log('Getting current sensor state.', 'debug');
 
     this.installation.getOverview()
       .then((overview) => overview.doorWindow.doorWindowDevice

--- a/lib/accessories/contactsensor.test.js
+++ b/lib/accessories/contactsensor.test.js
@@ -4,7 +4,7 @@ const ContactSensor = require('./contactsensor');
 
 describe('ContactSensor', () => {
   const homebridge = { hap };
-  const logger = jest.fn();
+  const logger = { info: jest.fn(), debug: jest.fn() };
   const config = {
     deviceLabel: 'DEFG 4567',
     area: 'Front door',

--- a/lib/accessories/doorlock.js
+++ b/lib/accessories/doorlock.js
@@ -38,7 +38,7 @@ class DoorLock extends VerisureAccessory {
   }
 
   getCurrentLockState(callback) {
-    this.log('Getting current lock state.');
+    this.log('Getting current lock state.', 'debug');
 
     // TODO: Use this.cachedValue, if available?
 

--- a/lib/accessories/doorlock.test.js
+++ b/lib/accessories/doorlock.test.js
@@ -4,7 +4,7 @@ const DoorLock = require('./doorlock');
 
 describe('DoorLock', () => {
   const homebridge = { hap };
-  const logger = jest.fn();
+  const logger = { info: jest.fn(), debug: jest.fn() };
   const config = {
     area: 'Entré',
     deviceLabel: '1234',

--- a/lib/accessories/smartplug.test.js
+++ b/lib/accessories/smartplug.test.js
@@ -4,7 +4,7 @@ const SmartPlug = require('./smartplug');
 
 describe('SmartPlug', () => {
   const homebridge = { hap };
-  const logger = jest.fn();
+  const logger = { info: jest.fn() };
   const config = {
     area: 'Living room',
     currentState: 'ON',

--- a/lib/accessories/verisure.js
+++ b/lib/accessories/verisure.js
@@ -54,7 +54,7 @@ class VerisureAccessory {
   }
 
   log(message, level = 'info') {
-    return this.logger(level, `${this.installation.config.alias} ${this.name}: ${message}`);
+    return this.logger[level](`${this.installation.config.alias} ${this.name}: ${message}`);
   }
 }
 

--- a/lib/accessories/verisure.js
+++ b/lib/accessories/verisure.js
@@ -53,8 +53,8 @@ class VerisureAccessory {
     });
   }
 
-  log(message) {
-    return this.logger('info', `${this.installation.config.alias} ${this.name}: ${message}`);
+  log(message, level = 'info') {
+    return this.logger(level, `${this.installation.config.alias} ${this.name}: ${message}`);
   }
 }
 

--- a/lib/accessories/verisure.test.js
+++ b/lib/accessories/verisure.test.js
@@ -12,7 +12,12 @@ describe('Verisure', () => {
     },
   };
 
-  const verisure = new Verisure(homebridge, jest.fn(), config, installation);
+  const logger = { info: jest.fn() };
+  const verisure = new Verisure(homebridge, logger, config, installation);
+
+  beforeEach(() => {
+    logger.info.mockClear();
+  });
 
   it('get lock state change result', () => {
     expect.assertions(5);
@@ -33,12 +38,8 @@ describe('Verisure', () => {
   });
 
   it('prefixes logs with installation and accessory name', () => {
-    const logger = jest.fn();
-    const verisureWithLogger = new Verisure(homebridge, logger, config, installation);
-
-    verisureWithLogger.name = 'SmartPlug (Hallway)';
-    verisureWithLogger.log('Something happened.');
-    expect(logger.mock.calls[0][0]).toBe('info');
-    expect(logger.mock.calls[0][1]).toBe('Home SmartPlug (Hallway): Something happened.');
+    verisure.name = 'SmartPlug (Hallway)';
+    verisure.log('Something happened.');
+    expect(logger.info.mock.calls[0][0]).toBe('Home SmartPlug (Hallway): Something happened.');
   });
 });


### PR DESCRIPTION
__What's the problem?__
Too verbose (noisy) logging due to polling.

__What's changed?__
Log level when getting a characteristic that's also used when polling.

__How can this be verified?__
No more logs when polling unless `debug` is enabled.

Fixes: https://github.com/ptz0n/homebridge-verisure/issues/93

---

__How to test__

__Update the plugin globally__

```bash
$ npm install -g git://github.com/ptz0n/homebridge-verisure#feature/log-less-when-polling
```

__Alt. run it manually__

```bash
$ git clone https://github.com/ptz0n/homebridge-verisure.git
$ cd homebridge-verisure
$ git checkout feature/log-less-when-polling
$ npm install
$ homebridge -P .
```