### PR TITLE
Update default accessory names to use allowed characters

### DIFF
--- a/lib/accessories/alarm.js
+++ b/lib/accessories/alarm.js
@@ -15,7 +15,7 @@ class Alarm extends VerisureAccessory {
     const { alarmCode } = this.platformConfig;
     this.alarmCode = alarmCode.toString();
     this.model = 'ALARM';
-    this.name = VerisureAccessory.getUniqueAccessoryName(`Alarm (${this.installation.config.alias})`);
+    this.name = VerisureAccessory.getUniqueAccessoryName(`Alarm - ${this.installation.config.alias}`);
 
     const { SecuritySystemCurrentState } = this.homebridge.hap.Characteristic;
     this.armStateMap = {

--- a/lib/accessories/alarm.test.js
+++ b/lib/accessories/alarm.test.js
@@ -21,7 +21,7 @@ describe('Alarm', () => {
   alarm.getServices();
 
   it('setup name', () => {
-    expect(alarm.name).toBe('Alarm (Kungsgatan)');
+    expect(alarm.name).toBe('Alarm - Kungsgatan');
   });
 
   it('resolves arm states', () => {

--- a/lib/accessories/climatesensor.js
+++ b/lib/accessories/climatesensor.js
@@ -22,7 +22,7 @@ class ClimateSensor extends VerisureAccessory {
     const name = _(deviceNames[label]) || label;
 
     this.model = label;
-    this.name = VerisureAccessory.getUniqueAccessoryName(`${name} (${area})`);
+    this.name = VerisureAccessory.getUniqueAccessoryName(`${name} - ${area}`);
   }
 
   getCurrentPropertyValue(property, callback) {

--- a/lib/accessories/climatesensor.test.js
+++ b/lib/accessories/climatesensor.test.js
@@ -27,7 +27,7 @@ describe('ClimateSensor', () => {
   const climateSensor = new ClimateSensor(homebridge, logger, config, installation);
 
   it('setup name and value', () => {
-    expect(climateSensor.name).toBe('Rökdetektor (Hallway)');
+    expect(climateSensor.name).toBe('Rökdetektor - Hallway');
   });
 
   it('gets current temperature', (done) => {
@@ -78,7 +78,7 @@ describe('ClimateSensor', () => {
     config.device.gui.label = 'FOOBAR';
     config.device.area = 'Kitchen';
     const anotherClimateSensor = new ClimateSensor(homebridge, logger, config, installation);
-    expect(anotherClimateSensor.name).toBe('FOOBAR (Kitchen)');
+    expect(anotherClimateSensor.name).toBe('FOOBAR - Kitchen');
   });
 
   it('expose only accessory & temp service', () => {

--- a/lib/accessories/doorlock.js
+++ b/lib/accessories/doorlock.js
@@ -13,11 +13,11 @@ class DoorLock extends VerisureAccessory {
     super(...args);
 
     const { area } = this.config.device;
-    this.name = VerisureAccessory.getUniqueAccessoryName(`SmartLock (${area})`);
+    this.name = VerisureAccessory.getUniqueAccessoryName(`SmartLock - ${area}`);
 
     this.doorCode = this.platformConfig.doorCode;
-    this.switchName = VerisureAccessory.getUniqueAccessoryName(`Auto-lock (${area})`);
-    this.audioName = VerisureAccessory.getUniqueAccessoryName(`Audio (${area})`);
+    this.switchName = VerisureAccessory.getUniqueAccessoryName(`Auto-lock - ${area}`);
+    this.audioName = VerisureAccessory.getUniqueAccessoryName(`Audio - ${area}`);
 
     // TODO: Could set currentLockState here.
   }

--- a/lib/accessories/doorlock.test.js
+++ b/lib/accessories/doorlock.test.js
@@ -33,9 +33,9 @@ describe('DoorLock', () => {
   doorLock.getServices();
 
   it('setup names and code', () => {
-    expect(doorLock.name).toBe('SmartLock (Entré)');
+    expect(doorLock.name).toBe('SmartLock - Entré');
 
-    expect(doorLock.switchName).toBe('Auto-lock (Entré)');
+    expect(doorLock.switchName).toBe('Auto-lock - Entré');
     expect(doorLock.doorCode).toBe('000000');
   });
 
@@ -89,7 +89,7 @@ describe('DoorLock', () => {
     const currentDoorLockValue = doorLock.value;
     doorLock.getCurrentLockState((error, value) => {
       expect(error).toBeTruthy();
-      expect(error.message).toBe('Could not find lock state for SmartLock (Entré).');
+      expect(error.message).toBe('Could not find lock state for SmartLock - Entré.');
       expect(value).toBeUndefined();
       expect(doorLock.value).toBe(currentDoorLockValue);
       done();

--- a/lib/accessories/smartplug.js
+++ b/lib/accessories/smartplug.js
@@ -6,7 +6,7 @@ class SmartPlug extends VerisureAccessory {
     super(...args);
 
     this.model = 'SMARTPLUG';
-    this.name = VerisureAccessory.getUniqueAccessoryName(`SmartPlug (${this.config.device.area})`);
+    this.name = VerisureAccessory.getUniqueAccessoryName(`SmartPlug - ${this.config.device.area}`);
     this.value = SmartPlug.resolveSwitchState(this.config.currentState);
   }
 

--- a/lib/accessories/smartplug.test.js
+++ b/lib/accessories/smartplug.test.js
@@ -22,7 +22,7 @@ describe('SmartPlug', () => {
   const smartPlug = new SmartPlug(homebridge, logger, config, installation);
 
   it('setup name and value', () => {
-    expect(smartPlug.name).toBe('SmartPlug (Living room)');
+    expect(smartPlug.name).toBe('SmartPlug - Living room');
     expect(smartPlug.value).toBe(true);
   });
 

--- a/lib/accessories/verisure.test.js
+++ b/lib/accessories/verisure.test.js
@@ -47,8 +47,8 @@ describe('Verisure', () => {
   });
 
   it('prefixes logs with installation and accessory name', () => {
-    verisure.name = 'SmartPlug (Hallway)';
+    verisure.name = 'SmartPlug - Hallway';
     verisure.log('Something happened.');
-    expect(logger.info.mock.calls[0][0]).toBe('Home SmartPlug (Hallway): Something happened.');
+    expect(logger.info.mock.calls[0][0]).toBe('Home SmartPlug - Hallway: Something happened.');
   });
 });


### PR DESCRIPTION
**What's the problem?**
In iOS 17, characters `(` and `)` is not allowed in accessory names. We use these when building default names.

**What's changed?**
Updated the default names to use `-` as separator instead of `(` and `)`.

**How can this be verified?**
Updated tests.

See: https://github.com/homebridge/HAP-NodeJS/issues/1008