### PR TITLE
Support Homebridge 2.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,12 @@ module.exports = {
     'jest/globals': true,
   },
   rules: {
-    'comma-dangle': ['error', 'always-multiline', { functions: 'never' }],
+    'comma-dangle': ['error', {
+      arrays: 'always-multiline',
+      objects: 'always-multiline',
+      imports: 'always-multiline',
+      exports: 'always-multiline',
+      functions: 'never',
+    }],
   },
 };

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 3.0.0 (May 4, 2026)
+
+### Plugin & accessories
+
+* Add support for Homebridge 2.0 alongside continued support for Homebridge 1.8+. The `engines.homebridge` range is now `^1.8.0 || ^2.0.0-beta.0` (the `-beta.0` suffix lets npm semver match the in-progress 2.0 beta releases as well as the final 2.0.0 release).
+* Migrate all accessories from the deprecated `EventEmitter`-style `.on('get', cb)` / `.on('set', cb)` characteristic handlers to the `onGet` / `onSet` async API required by HAP-NodeJS 1.x.
+* Replace `setCharacteristic` with `updateCharacteristic` when reflecting state back to HAP, to avoid re-triggering set handlers.
+* Rewrite the polling loop to call each registered getter and push the result via `updateValue`, since `Characteristic#getValue()` was removed in HAP-NodeJS 1.x.
+
+### Breaking
+
+* __BREAKING__: Node.js 18 is now the minimum supported version (was Node.js 12).
+* __BREAKING__: Homebridge 1.8 is now the minimum supported version (was 1.0).
+
+### Dependencies
+
+* Replace `hap-nodejs` dev dependency with `@homebridge/hap-nodejs ^2.0.0`. The package was renamed and bumped as part of the Homebridge 2.0 release. Test imports updated accordingly.
+* Bump `homebridge` dev dependency to `^2.0.0`.
+* Bump `eslint` to `^8.57.0`, `jest` to `^29.0.0`, and related plugins.
+
 ## 2.0.2 (Feb 10, 2026)
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Please protect you installation from unauthorised access:
 3. Remove access from users that no longer need it.
 4. Keep your devices up to date.
 
+## Requirements
+
+* Node.js 18 or later
+* Homebridge 1.8 or later (also compatible with Homebridge 2.0)
+
 ## Installation
 
 ```bash

--- a/lib/accessories/alarm.js
+++ b/lib/accessories/alarm.js
@@ -45,17 +45,14 @@ class Alarm extends VerisureAccessory {
     return output;
   }
 
-  getCurrentAlarmState(callback) {
+  async getCurrentAlarmState() {
     this.log('Getting current alarm state.', 'debug');
 
-    this.installation.client(overviewOperation)
-      .then((overview) => {
-        callback(null, this.resolveArmState(overview.installation.armState.statusType));
-      })
-      .catch(callback);
+    const overview = await this.installation.client(overviewOperation);
+    return this.resolveArmState(overview.installation.armState.statusType);
   }
 
-  setTargetAlarmState(value, callback) {
+  async setTargetAlarmState(value) {
     this.log(`Setting target alarm state to: ${value}`);
 
     const targetArmState = this.resolveArmState(value);
@@ -66,19 +63,15 @@ class Alarm extends VerisureAccessory {
       DISARMED: disarmOperation,
     }[targetArmState](this.alarmCode);
 
-    this.installation.client(operation)
-      .then(({ transactionId }) => this.resolveChangeResult(
-        pollArmStateOperation(transactionId, targetArmState),
-      ))
-      .then(() => {
-        callback(); // Successful action.
+    const { transactionId } = await this.installation.client(operation);
+    await this.resolveChangeResult(
+      pollArmStateOperation(transactionId, targetArmState)
+    );
 
-        setImmediate(() => {
-          const { SecuritySystemCurrentState } = this.homebridge.hap.Characteristic;
-          this.service.setCharacteristic(SecuritySystemCurrentState, value);
-        });
-      })
-      .catch(callback);
+    setImmediate(() => {
+      const { SecuritySystemCurrentState } = this.homebridge.hap.Characteristic;
+      this.service.updateCharacteristic(SecuritySystemCurrentState, value);
+    });
   }
 
   getServices() {
@@ -88,12 +81,12 @@ class Alarm extends VerisureAccessory {
 
     const currentStateCharacteristic = this.service
       .getCharacteristic(Characteristic.SecuritySystemCurrentState)
-      .on('get', this.getCurrentAlarmState.bind(this));
+      .onGet(this.getCurrentAlarmState.bind(this));
 
     const targetStateCharacteristic = this.service
       .getCharacteristic(Characteristic.SecuritySystemTargetState)
-      .on('get', this.getCurrentAlarmState.bind(this))
-      .on('set', this.setTargetAlarmState.bind(this));
+      .onGet(this.getCurrentAlarmState.bind(this))
+      .onSet(this.setTargetAlarmState.bind(this));
 
     const { NIGHT_ARM } = Characteristic.SecuritySystemTargetState;
     const validValues = targetStateCharacteristic.props.validValues
@@ -102,7 +95,10 @@ class Alarm extends VerisureAccessory {
 
     this.accessoryInformation.setCharacteristic(Characteristic.Model, this.model);
 
-    this.pollCharacteristics.push(currentStateCharacteristic);
+    this.pollCharacteristics.push({
+      characteristic: currentStateCharacteristic,
+      getter: this.getCurrentAlarmState.bind(this),
+    });
 
     return [this.accessoryInformation, this.service];
   }

--- a/lib/accessories/alarm.js
+++ b/lib/accessories/alarm.js
@@ -63,7 +63,25 @@ class Alarm extends VerisureAccessory {
       DISARMED: disarmOperation,
     }[targetArmState](this.alarmCode);
 
-    const { transactionId } = await this.installation.client(operation);
+    let transactionId;
+    try {
+      ({ transactionId } = await this.installation.client(operation));
+    } catch (error) {
+      if (error.name !== 'GraphqlException') {
+        throw error;
+      }
+      this.log(`Arm state change to ${targetArmState} failed: ${JSON.stringify(error.errors)}. Retrying once.`, 'warn');
+      await new Promise((resolve) => { setTimeout(resolve, 2000); });
+      try {
+        ({ transactionId } = await this.installation.client(operation));
+      } catch (retryError) {
+        if (retryError.name === 'GraphqlException') {
+          retryError.message += `: ${JSON.stringify(retryError.errors)}`;
+        }
+        throw retryError;
+      }
+    }
+
     await this.resolveChangeResult(
       pollArmStateOperation(transactionId, targetArmState)
     );

--- a/lib/accessories/alarm.test.js
+++ b/lib/accessories/alarm.test.js
@@ -1,4 +1,4 @@
-const hap = require('hap-nodejs');
+const hap = require('@homebridge/hap-nodejs');
 
 const Alarm = require('./alarm');
 
@@ -16,7 +16,13 @@ describe('Alarm', () => {
     alarmCode: '000000',
   };
   const { SecuritySystemCurrentState } = hap.Characteristic;
-  const alarm = new Alarm(homebridge, logger, config, installation, platformConfig);
+  const alarm = new Alarm(
+    homebridge,
+    logger,
+    config,
+    installation,
+    platformConfig
+  );
 
   alarm.getServices();
 
@@ -25,19 +31,31 @@ describe('Alarm', () => {
   });
 
   it('resolves arm states', () => {
-    expect(alarm.resolveArmState('ARMED_AWAY')).toBe(SecuritySystemCurrentState.AWAY_ARM);
-    expect(alarm.resolveArmState('ARMED_HOME')).toBe(SecuritySystemCurrentState.STAY_ARM);
-    expect(alarm.resolveArmState('DISARMED')).toBe(SecuritySystemCurrentState.DISARMED);
+    expect(alarm.resolveArmState('ARMED_AWAY')).toBe(
+      SecuritySystemCurrentState.AWAY_ARM
+    );
+    expect(alarm.resolveArmState('ARMED_HOME')).toBe(
+      SecuritySystemCurrentState.STAY_ARM
+    );
+    expect(alarm.resolveArmState('DISARMED')).toBe(
+      SecuritySystemCurrentState.DISARMED
+    );
 
-    expect(alarm.resolveArmState(SecuritySystemCurrentState.AWAY_ARM)).toBe('ARMED_AWAY');
-    expect(alarm.resolveArmState(SecuritySystemCurrentState.STAY_ARM)).toBe('ARMED_HOME');
-    expect(alarm.resolveArmState(SecuritySystemCurrentState.DISARMED)).toBe('DISARMED');
+    expect(alarm.resolveArmState(SecuritySystemCurrentState.AWAY_ARM)).toBe(
+      'ARMED_AWAY'
+    );
+    expect(alarm.resolveArmState(SecuritySystemCurrentState.STAY_ARM)).toBe(
+      'ARMED_HOME'
+    );
+    expect(alarm.resolveArmState(SecuritySystemCurrentState.DISARMED)).toBe(
+      'DISARMED'
+    );
 
     expect(() => alarm.resolveArmState('FOOBAR')).toThrow();
   });
 
-  it('requests current arm state', (done) => {
-    expect.assertions(2);
+  it('requests current arm state', async () => {
+    expect.assertions(1);
     installation.client = jest.fn();
     installation.client.mockResolvedValueOnce({
       installation: {
@@ -46,14 +64,11 @@ describe('Alarm', () => {
         },
       },
     });
-    alarm.getCurrentAlarmState((error, value) => {
-      expect(error).toBeFalsy();
-      expect(value).toBe(SecuritySystemCurrentState.AWAY_ARM);
-      done();
-    });
+    const value = await alarm.getCurrentAlarmState();
+    expect(value).toBe(SecuritySystemCurrentState.AWAY_ARM);
   });
 
-  it('sets target arm state', (done) => {
+  it('sets target arm state', async () => {
     expect.assertions(2);
     installation.client = jest.fn();
     installation.client.mockResolvedValueOnce({
@@ -67,14 +82,17 @@ describe('Alarm', () => {
       },
     });
 
-    alarm.setTargetAlarmState(SecuritySystemCurrentState.AWAY_ARM, (error) => {
-      expect(error).toBeFalsy();
+    await alarm.setTargetAlarmState(SecuritySystemCurrentState.AWAY_ARM);
 
-      setTimeout(() => { // Wait for setImmediate
-        expect(alarm.service.getCharacteristic(SecuritySystemCurrentState).value)
-          .toBe(SecuritySystemCurrentState.AWAY_ARM);
-        done();
-      }, 100);
+    const { calls } = installation.client.mock;
+    expect(calls.length).toBe(2);
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
     });
+
+    expect(
+      alarm.service.getCharacteristic(SecuritySystemCurrentState).value
+    ).toBe(SecuritySystemCurrentState.AWAY_ARM);
   });
 });

--- a/lib/accessories/alarm.test.js
+++ b/lib/accessories/alarm.test.js
@@ -4,7 +4,7 @@ const Alarm = require('./alarm');
 
 describe('Alarm', () => {
   const homebridge = { hap };
-  const logger = { info: jest.fn(), debug: jest.fn() };
+  const logger = { info: jest.fn(), debug: jest.fn(), warn: jest.fn() };
   const config = {
     statusType: 'DISARMED',
   };
@@ -94,5 +94,77 @@ describe('Alarm', () => {
     expect(
       alarm.service.getCharacteristic(SecuritySystemCurrentState).value
     ).toBe(SecuritySystemCurrentState.AWAY_ARM);
+  });
+
+  it('retries once when arm state change is rejected', async () => {
+    jest.useFakeTimers();
+    installation.client = jest.fn();
+
+    const error = new Error('GraphQL response contains 1 errors');
+    error.name = 'GraphqlException';
+    error.errors = [{ message: 'System busy' }];
+
+    installation.client.mockRejectedValueOnce(error);
+    installation.client.mockResolvedValueOnce({
+      transactionId: 'asd123',
+    });
+    installation.client.mockResolvedValueOnce({
+      installation: {
+        pollResult: {
+          result: 'OK',
+        },
+      },
+    });
+
+    const promise = alarm.setTargetAlarmState(
+      SecuritySystemCurrentState.STAY_ARM
+    );
+    await jest.advanceTimersByTimeAsync(2000);
+    await promise;
+
+    expect(installation.client.mock.calls.length).toBe(3);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Kungsgatan Alarm - Kungsgatan: Arm state change to ARMED_HOME failed: [{"message":"System busy"}]. Retrying once.'
+    );
+
+    jest.useRealTimers();
+  });
+
+  it('includes error details when the retry is rejected', async () => {
+    jest.useFakeTimers();
+    installation.client = jest.fn();
+
+    const makeError = () => {
+      const error = new Error('GraphQL response contains 1 errors');
+      error.name = 'GraphqlException';
+      error.errors = [{ message: 'System busy' }];
+      return error;
+    };
+
+    installation.client.mockRejectedValueOnce(makeError());
+    installation.client.mockRejectedValueOnce(makeError());
+
+    const promise = alarm.setTargetAlarmState(
+      SecuritySystemCurrentState.DISARMED
+    );
+    promise.catch(() => {});
+    await jest.advanceTimersByTimeAsync(2000);
+
+    await expect(promise).rejects.toThrow(
+      'GraphQL response contains 1 errors: [{"message":"System busy"}]'
+    );
+    expect(installation.client.mock.calls.length).toBe(2);
+
+    jest.useRealTimers();
+  });
+
+  it('does not retry other errors', async () => {
+    installation.client = jest.fn();
+    installation.client.mockRejectedValueOnce(new Error('socket hang up'));
+
+    await expect(
+      alarm.setTargetAlarmState(SecuritySystemCurrentState.DISARMED)
+    ).rejects.toThrow('socket hang up');
+    expect(installation.client.mock.calls.length).toBe(1);
   });
 });

--- a/lib/accessories/climatesensor.js
+++ b/lib/accessories/climatesensor.js
@@ -27,7 +27,10 @@ class ClimateSensor extends VerisureAccessory {
     const name = _(deviceNames[label]) || label;
 
     this.model = label;
-    this.name = VerisureAccessory.getUniqueAccessoryName(`${name} - ${(area || '').trim()}`);
+    const areaName = (area || '').trim();
+    this.name = VerisureAccessory.getUniqueAccessoryName(
+      areaName ? `${name} - ${areaName}` : name
+    );
   }
 
   async getCurrentPropertyValue(property) {

--- a/lib/accessories/climatesensor.js
+++ b/lib/accessories/climatesensor.js
@@ -17,24 +17,28 @@ class ClimateSensor extends VerisureAccessory {
   constructor(...args) {
     super(...args);
 
-    const { device: { area, gui: { label } } } = this.config;
+    const {
+      device: {
+        area,
+        gui: { label },
+      },
+    } = this.config;
     const _ = i18n(this.installation.locale);
     const name = _(deviceNames[label]) || label;
 
     this.model = label;
-    this.name = VerisureAccessory.getUniqueAccessoryName(`${name} - ${area}`);
+    this.name = VerisureAccessory.getUniqueAccessoryName(`${name} - ${(area || '').trim()}`);
   }
 
-  getCurrentPropertyValue(property, callback) {
+  async getCurrentPropertyValue(property) {
     this.log(`Getting current ${property} value.`);
 
-    this.installation.client(overviewOperation)
-      .then((overview) => overview.installation.climates
-        .find((climate) => climate.device.deviceLabel === this.serialNumber))
-      .then((device) => {
-        callback(null, device[`${property}Value`]);
-      })
-      .catch(callback);
+    const overview = await this.installation.client(overviewOperation);
+    const device = overview.installation.climates.find(
+      (climate) => climate.device.deviceLabel === this.serialNumber
+    );
+
+    return device[`${property}Value`];
   }
 
   getServices() {
@@ -49,7 +53,7 @@ class ClimateSensor extends VerisureAccessory {
       this.temperatureService
         .getCharacteristic(Characteristic.CurrentTemperature)
         .setProps({ minValue: -40.0, maxValue: 60.0 })
-        .on('get', this.getCurrentPropertyValue.bind(this, 'temperature'));
+        .onGet(this.getCurrentPropertyValue.bind(this, 'temperature'));
       services.push(this.temperatureService);
     }
 
@@ -57,7 +61,7 @@ class ClimateSensor extends VerisureAccessory {
       this.humidityService = new Service.HumiditySensor(this.name);
       this.humidityService
         .getCharacteristic(Characteristic.CurrentRelativeHumidity)
-        .on('get', this.getCurrentPropertyValue.bind(this, 'humidity'));
+        .onGet(this.getCurrentPropertyValue.bind(this, 'humidity'));
       services.push(this.humidityService);
     }
 

--- a/lib/accessories/climatesensor.test.js
+++ b/lib/accessories/climatesensor.test.js
@@ -1,4 +1,4 @@
-const hap = require('hap-nodejs');
+const hap = require('@homebridge/hap-nodejs');
 
 const ClimateSensor = require('./climatesensor');
 
@@ -30,8 +30,8 @@ describe('ClimateSensor', () => {
     expect(climateSensor.name).toBe('Rökdetektor - Hallway');
   });
 
-  it('gets current temperature', (done) => {
-    expect.assertions(2);
+  it('gets current temperature', async () => {
+    expect.assertions(1);
 
     installation.client = jest.fn();
     installation.client.mockResolvedValueOnce({
@@ -45,15 +45,12 @@ describe('ClimateSensor', () => {
       },
     });
 
-    climateSensor.getCurrentPropertyValue('temperature', (error, value) => {
-      expect(error).toBeNull();
-      expect(value).toBe(22.5);
-      done();
-    });
+    const value = await climateSensor.getCurrentPropertyValue('temperature');
+    expect(value).toBe(22.5);
   });
 
-  it('gets current relative humidity', (done) => {
-    expect.assertions(2);
+  it('gets current relative humidity', async () => {
+    expect.assertions(1);
 
     installation.client = jest.fn();
     installation.client.mockResolvedValueOnce({
@@ -67,11 +64,8 @@ describe('ClimateSensor', () => {
       },
     });
 
-    climateSensor.getCurrentPropertyValue('humidity', (error, value) => {
-      expect(error).toBeNull();
-      expect(value).toBe(62);
-      done();
-    });
+    const value = await climateSensor.getCurrentPropertyValue('humidity');
+    expect(value).toBe(62);
   });
 
   it('setup name for unknown device type', () => {

--- a/lib/accessories/contactsensor.js
+++ b/lib/accessories/contactsensor.js
@@ -5,9 +5,12 @@ class ContactSensor extends VerisureAccessory {
   constructor(...args) {
     super(...args);
 
-    const { device: { area }, state } = this.config;
+    const {
+      device: { area },
+      state,
+    } = this.config;
 
-    this.name = VerisureAccessory.getUniqueAccessoryName(area);
+    this.name = VerisureAccessory.getUniqueAccessoryName((area || '').trim());
     this.value = ContactSensor.resolveSensorState(state);
   }
 
@@ -15,17 +18,16 @@ class ContactSensor extends VerisureAccessory {
     return input !== 'CLOSE';
   }
 
-  getCurrentSensorState(callback) {
+  async getCurrentSensorState() {
     this.log('Getting current sensor state.', 'debug');
 
-    this.installation.client(overviewOperation)
-      .then((overview) => overview.installation.doorWindows
-        .find((doorWindow) => doorWindow.device.deviceLabel === this.serialNumber))
-      .then((doorWindow) => {
-        this.value = ContactSensor.resolveSensorState(doorWindow.state);
-        callback(null, this.value);
-      })
-      .catch(callback);
+    const overview = await this.installation.client(overviewOperation);
+    const doorWindow = overview.installation.doorWindows.find(
+      (dw) => dw.device.deviceLabel === this.serialNumber
+    );
+
+    this.value = ContactSensor.resolveSensorState(doorWindow.state);
+    return this.value;
   }
 
   getServices() {
@@ -34,9 +36,12 @@ class ContactSensor extends VerisureAccessory {
     this.service = new Service.ContactSensor(this.name);
     const currentStateCharacteristic = this.service
       .getCharacteristic(Characteristic.ContactSensorState)
-      .on('get', this.getCurrentSensorState.bind(this));
+      .onGet(this.getCurrentSensorState.bind(this));
 
-    this.pollCharacteristics.push(currentStateCharacteristic);
+    this.pollCharacteristics.push({
+      characteristic: currentStateCharacteristic,
+      getter: this.getCurrentSensorState.bind(this),
+    });
 
     return [this.accessoryInformation, this.service];
   }

--- a/lib/accessories/contactsensor.js
+++ b/lib/accessories/contactsensor.js
@@ -10,7 +10,7 @@ class ContactSensor extends VerisureAccessory {
       state,
     } = this.config;
 
-    this.name = VerisureAccessory.getUniqueAccessoryName((area || '').trim());
+    this.name = VerisureAccessory.getUniqueAccessoryName((area || '').trim() || 'Contact sensor');
     this.value = ContactSensor.resolveSensorState(state);
   }
 

--- a/lib/accessories/contactsensor.test.js
+++ b/lib/accessories/contactsensor.test.js
@@ -1,4 +1,4 @@
-const hap = require('hap-nodejs');
+const hap = require('@homebridge/hap-nodejs');
 
 const ContactSensor = require('./contactsensor');
 
@@ -32,8 +32,8 @@ describe('ContactSensor', () => {
     expect(ContactSensor.resolveSensorState('ASD')).toBe(true);
   });
 
-  it('gets current state', (done) => {
-    expect.assertions(3);
+  it('gets current state', async () => {
+    expect.assertions(2);
 
     installation.client = jest.fn();
     installation.client.mockResolvedValueOnce({
@@ -47,12 +47,9 @@ describe('ContactSensor', () => {
       },
     });
 
-    contactSensor.getCurrentSensorState((error, value) => {
-      expect(error).toBeNull();
-      expect(value).toBe(true);
-      expect(contactSensor.value).toBe(true);
-      done();
-    });
+    const value = await contactSensor.getCurrentSensorState();
+    expect(value).toBe(true);
+    expect(contactSensor.value).toBe(true);
   });
 
   it('exposes services', () => {

--- a/lib/accessories/doorlock.js
+++ b/lib/accessories/doorlock.js
@@ -13,11 +13,11 @@ class DoorLock extends VerisureAccessory {
     super(...args);
 
     const area = (this.config.device.area || '').trim();
-    this.name = VerisureAccessory.getUniqueAccessoryName(`SmartLock - ${area}`);
+    this.name = VerisureAccessory.getUniqueAccessoryName(area ? `SmartLock - ${area}` : 'SmartLock');
 
     this.doorCode = this.platformConfig.doorCode;
-    this.switchName = VerisureAccessory.getUniqueAccessoryName(`Auto-lock - ${area}`);
-    this.audioName = VerisureAccessory.getUniqueAccessoryName(`Audio - ${area}`);
+    this.switchName = VerisureAccessory.getUniqueAccessoryName(area ? `Auto-lock - ${area}` : 'Auto-lock');
+    this.audioName = VerisureAccessory.getUniqueAccessoryName(area ? `Audio - ${area}` : 'Audio');
 
     // TODO: Could set currentLockState here.
   }

--- a/lib/accessories/doorlock.js
+++ b/lib/accessories/doorlock.js
@@ -12,7 +12,7 @@ class DoorLock extends VerisureAccessory {
   constructor(...args) {
     super(...args);
 
-    const { area } = this.config.device;
+    const area = (this.config.device.area || '').trim();
     this.name = VerisureAccessory.getUniqueAccessoryName(`SmartLock - ${area}`);
 
     this.doorCode = this.platformConfig.doorCode;
@@ -29,145 +29,131 @@ class DoorLock extends VerisureAccessory {
       return LockCurrentState.JAMMED;
     }
 
-    return currentLockState === 'LOCKED'
-      ? LockCurrentState.SECURED
-      : LockCurrentState.UNSECURED;
+    return currentLockState === 'LOCKED' ? LockCurrentState.SECURED : LockCurrentState.UNSECURED;
   }
 
-  getDoorLockState() {
+  async getDoorLockState() {
     this.log('Getting current lock state.', 'debug');
 
-    return this.installation.client(overviewOperation)
-      .then((overview) => overview.installation.doorlocks
-        .find((doorlock) => doorlock.device.deviceLabel === this.serialNumber))
-      .then((doorLock) => {
-        if (!doorLock) {
-          throw Error(`Could not find lock state for ${this.name}.`);
-        }
-        return doorLock;
-      });
+    const overview = await this.installation.client(overviewOperation);
+    const doorLock = overview.installation.doorlocks.find(
+      (dl) => dl.device.deviceLabel === this.serialNumber
+    );
+
+    if (!doorLock) {
+      throw Error(`Could not find lock state for ${this.name}.`);
+    }
+
+    return doorLock;
   }
 
-  getCurrentLockState(callback) {
+  async getCurrentLockState() {
     // TODO: Use this.cachedValue, if available?
 
-    this.getDoorLockState().then((doorLock) => {
-      callback(null, this.resolveCurrentLockState(doorLock));
-    }).catch(callback);
+    const doorLock = await this.getDoorLockState();
+    return this.resolveCurrentLockState(doorLock);
   }
 
-  getTargetLockState(callback) {
+  async getTargetLockState() {
     this.log('Getting target lock state.');
 
-    this.getDoorLockState().then(({ currentLockState }) => {
-      const { LockTargetState } = this.homebridge.hap.Characteristic;
+    const { currentLockState } = await this.getDoorLockState();
+    const { LockTargetState } = this.homebridge.hap.Characteristic;
 
-      const targetLockState = this.targetLockState || currentLockState;
+    const targetLockState = this.targetLockState || currentLockState;
 
-      callback(null, targetLockState === 'LOCKED'
-        ? LockTargetState.SECURED
-        : LockTargetState.UNSECURED);
-    }).catch((error) => {
-      callback(error);
-    });
+    return targetLockState === 'LOCKED' ? LockTargetState.SECURED : LockTargetState.UNSECURED;
   }
 
-  setTargetLockState(value, callback) {
+  async setTargetLockState(value) {
     this.log(`Setting target lock state to: ${value}`);
 
-    this.targetLockState = value === this.homebridge.hap.Characteristic.LockCurrentState.SECURED
-      ? 'LOCKED'
-      : 'UNLOCKED';
+    this.targetLockState = value === this.homebridge.hap.Characteristic.LockCurrentState.SECURED ? 'LOCKED' : 'UNLOCKED';
 
-    const operation = this.targetLockState === 'LOCKED'
-      ? doorLockOperation
-      : doorUnlockOperation;
+    const operation = this.targetLockState === 'LOCKED' ? doorLockOperation : doorUnlockOperation;
 
-    this.installation.client(operation(this.serialNumber, this.doorCode))
-      .then(({ transactionId }) => this.resolveChangeResult(
-        pollLockStateOperation(transactionId, this.serialNumber, this.targetLockState),
-      ))
-      .catch((error) => {
-        const isAlreadyAtTargetStateError = error.errors && error.errors
-          .find(({ data: { errorCode } }) => errorCode === 'VAL_00819');
-        if (isAlreadyAtTargetStateError) {
-          return true; // Lock at desired state.
-        }
-
+    try {
+      const { transactionId } = await this.installation.client(
+        operation(this.serialNumber, this.doorCode)
+      );
+      await this.resolveChangeResult(
+        pollLockStateOperation(transactionId, this.serialNumber, this.targetLockState)
+      );
+    } catch (error) {
+      const isAlreadyAtTargetStateError = error.errors && error.errors.find(({ data: { errorCode } }) => errorCode === 'VAL_00819');
+      if (!isAlreadyAtTargetStateError) {
         throw error;
-      })
-      .then(() => {
-        callback(); // Successful action.
+      }
+      // Lock at desired state, continue.
+    }
 
-        setImmediate(() => {
-          const { LockCurrentState } = this.homebridge.hap.Characteristic;
-          this.lockService.setCharacteristic(LockCurrentState, value);
-        });
-        // TODO: Set this.cachedValue with TTL?
-      })
-      .catch(callback);
+    setImmediate(() => {
+      const { LockCurrentState } = this.homebridge.hap.Characteristic;
+      this.lockService.updateCharacteristic(LockCurrentState, value);
+    });
+    // TODO: Set this.cachedValue with TTL?
   }
 
   static resolveAutoLockState(config) {
     return config.autoLockEnabled === true;
   }
 
-  getAutoLockState(callback) {
+  async getAutoLockState() {
     this.log('Getting current auto lock config.');
 
-    this.installation.client(doorLockConfigOperation(this.serialNumber))
-      .then(({ installation: { smartLocks: [smartLock] } }) => {
-        this.autoLockState = DoorLock.resolveAutoLockState(smartLock.configuration);
-        callback(null, this.autoLockState);
-      })
-      .catch(callback);
+    const {
+      installation: {
+        smartLocks: [smartLock],
+      },
+    } = await this.installation.client(doorLockConfigOperation(this.serialNumber));
+
+    this.autoLockState = DoorLock.resolveAutoLockState(smartLock.configuration);
+    return this.autoLockState;
   }
 
-  setAutoLockState(value, callback) {
+  async setAutoLockState(value) {
     this.log(`Setting auto lock to: ${value}`);
 
     this.autoLockState = value;
 
-    this.installation.client(
-      doorLockUpdateConfigOperation(this.serialNumber, { autoLockEnabled: value }),
-    )
-      .then(() => callback(null))
-      .catch((error) => {
-        this.log(error.message, 'debug');
-        // TODO: Revert config state in this.value?
-        callback({ message: error.errorMessage });
-      });
+    try {
+      await this.installation.client(
+        doorLockUpdateConfigOperation(this.serialNumber, { autoLockEnabled: value })
+      );
+    } catch (error) {
+      this.log(error.message, 'debug');
+      // TODO: Revert config state in this.value?
+      throw new Error(error.errorMessage);
+    }
   }
 
-  getAudioState(callback) {
+  async getAudioState() {
     this.log('Getting current audio config.');
 
-    this.installation.client(doorLockConfigOperation(this.serialNumber))
-      .then(({ installation: { smartLocks: [smartLock] } }) => {
-        this.audioState = smartLock.configuration.volume !== this.platformConfig.audioOffValue;
-        callback(null, this.audioState);
-      })
-      .catch(callback);
+    const {
+      installation: {
+        smartLocks: [smartLock],
+      },
+    } = await this.installation.client(doorLockConfigOperation(this.serialNumber));
+
+    this.audioState = smartLock.configuration.volume !== this.platformConfig.audioOffValue;
+    return this.audioState;
   }
 
-  setAudioState(value, callback) {
+  async setAudioState(value) {
     this.audioState = value;
 
-    const volume = value
-      ? this.platformConfig.audioOnValue
-      : this.platformConfig.audioOffValue;
+    const volume = value ? this.platformConfig.audioOnValue : this.platformConfig.audioOffValue;
 
     this.log(`Setting audio volume to: ${volume}`);
 
-    this.installation.client(
-      doorLockUpdateConfigOperation(this.serialNumber, { volume }),
-    )
-      .then(() => callback(null))
-      .catch((error) => {
-        this.log(error.message, 'debug');
-        // TODO: Revert config state in this.value?
-        callback({ message: error.errorMessage });
-      });
+    try {
+      await this.installation.client(doorLockUpdateConfigOperation(this.serialNumber, { volume }));
+    } catch (error) {
+      this.log(error.message, 'debug');
+      // TODO: Revert config state in this.value?
+      throw new Error(error.errorMessage);
+    }
   }
 
   getServices() {
@@ -178,12 +164,12 @@ class DoorLock extends VerisureAccessory {
     this.lockService = new Service.LockMechanism(this.name);
     const currentStateCharacteristic = this.lockService
       .getCharacteristic(Characteristic.LockCurrentState)
-      .on('get', this.getCurrentLockState.bind(this));
+      .onGet(this.getCurrentLockState.bind(this));
 
     this.lockService
       .getCharacteristic(Characteristic.LockTargetState)
-      .on('get', this.getTargetLockState.bind(this))
-      .on('set', this.setTargetLockState.bind(this));
+      .onGet(this.getTargetLockState.bind(this))
+      .onSet(this.setTargetLockState.bind(this));
 
     services.push(this.lockService);
 
@@ -191,8 +177,8 @@ class DoorLock extends VerisureAccessory {
       this.autoLockService = new Service.Switch(this.switchName, this.switchName);
       this.autoLockService
         .getCharacteristic(Characteristic.On)
-        .on('get', this.getAutoLockState.bind(this))
-        .on('set', this.setAutoLockState.bind(this));
+        .onGet(this.getAutoLockState.bind(this))
+        .onSet(this.setAutoLockState.bind(this));
 
       services.push(this.autoLockService);
     }
@@ -201,13 +187,16 @@ class DoorLock extends VerisureAccessory {
       this.audioService = new Service.Switch(this.audioName, this.audioName);
       this.audioService
         .getCharacteristic(Characteristic.On)
-        .on('get', this.getAudioState.bind(this))
-        .on('set', this.setAudioState.bind(this));
+        .onGet(this.getAudioState.bind(this))
+        .onSet(this.setAudioState.bind(this));
 
       services.push(this.audioService);
     }
 
-    this.pollCharacteristics.push(currentStateCharacteristic);
+    this.pollCharacteristics.push({
+      characteristic: currentStateCharacteristic,
+      getter: this.getCurrentLockState.bind(this),
+    });
 
     return services;
   }

--- a/lib/accessories/doorlock.test.js
+++ b/lib/accessories/doorlock.test.js
@@ -1,10 +1,10 @@
-const hap = require('hap-nodejs');
+const hap = require('@homebridge/hap-nodejs');
 
 const DoorLock = require('./doorlock');
 
 describe('DoorLock', () => {
   const homebridge = { hap };
-  const logger = { info: console.log, debug: console.debug };
+  const logger = { info: jest.fn(), debug: jest.fn() };
   const config = {
     device: {
       area: 'Entré',
@@ -45,7 +45,9 @@ describe('DoorLock', () => {
   });
 
   it('resolves secured lock state', () => {
-    const state = doorLock.resolveCurrentLockState({ currentLockState: 'LOCKED' });
+    const state = doorLock.resolveCurrentLockState({
+      currentLockState: 'LOCKED',
+    });
     expect(state).toBe(LockCurrentState.SECURED);
   });
 
@@ -57,71 +59,68 @@ describe('DoorLock', () => {
     expect(state).toBe(LockCurrentState.JAMMED);
   });
 
-  it('gets lock state', (done) => {
+  it('gets lock state', async () => {
+    expect.assertions(1);
+    installation.client = () => Promise.resolve({
+      installation: {
+        doorlocks: [
+          {
+            device: {
+              deviceLabel: doorLock.serialNumber,
+            },
+            currentLockState: 'LOCKED',
+          },
+        ],
+      },
+    });
+    const value = await doorLock.getCurrentLockState();
+    expect(value).toBe(LockCurrentState.SECURED);
+  });
+
+  it('errors when not able to get lock state', async () => {
     expect.assertions(2);
     installation.client = () => Promise.resolve({
       installation: {
-        doorlocks: [{
-          device: {
-            deviceLabel: doorLock.serialNumber,
+        doorlocks: [
+          {
+            device: { deviceLabel: 'NOT MATCHING LABEL' },
+            currentLockState: 'LOCKED',
           },
-          currentLockState: 'LOCKED',
-        }],
-      },
-    });
-    doorLock.getCurrentLockState((error, value) => {
-      expect(error).toBeFalsy();
-      expect(value).toBe(LockCurrentState.SECURED);
-      done();
-    });
-  });
-
-  it('errors when not able to get lock state', (done) => {
-    expect.assertions(4);
-    installation.client = () => Promise.resolve({
-      installation: {
-        doorlocks: [{
-          device: { deviceLabel: 'NOT MATCHING LABEL' },
-          currentLockState: 'LOCKED',
-        }],
+        ],
       },
     });
     const currentDoorLockValue = doorLock.value;
-    doorLock.getCurrentLockState((error, value) => {
-      expect(error).toBeTruthy();
-      expect(error.message).toBe('Could not find lock state for SmartLock - Entré.');
-      expect(value).toBeUndefined();
-      expect(doorLock.value).toBe(currentDoorLockValue);
-      done();
-    });
+    await expect(doorLock.getCurrentLockState()).rejects.toThrow(
+      'Could not find lock state for SmartLock - Entré.'
+    );
+    expect(doorLock.value).toBe(currentDoorLockValue);
   });
 
-  it('get target lock state', (done) => {
-    expect.assertions(2);
+  it('get target lock state', async () => {
+    expect.assertions(1);
     installation.client = jest.fn();
     installation.client.mockResolvedValueOnce({
       installation: {
-        doorlocks: [{
-          device: {
-            deviceLabel: doorLock.serialNumber,
+        doorlocks: [
+          {
+            device: {
+              deviceLabel: doorLock.serialNumber,
+            },
+            currentLockState: 'UNLOCKED',
           },
-          currentLockState: 'UNLOCKED',
-        }],
+        ],
       },
     });
 
     // Should overwride currentLockState from response.
     doorLock.targetLockState = 'LOCKED';
 
-    doorLock.getTargetLockState((error, value) => {
-      expect(error).toBeNull();
-      expect(value).toBe(LockTargetState.SECURED);
-      done();
-    });
+    const value = await doorLock.getTargetLockState();
+    expect(value).toBe(LockTargetState.SECURED);
   });
 
-  it('sets target lock state', (done) => {
-    expect.assertions(3);
+  it('sets target lock state', async () => {
+    expect.assertions(2);
     installation.client = jest.fn();
     installation.client.mockResolvedValueOnce({
       transactionId: 'asd123',
@@ -141,56 +140,58 @@ describe('DoorLock', () => {
       },
     });
 
-    doorLock.setTargetLockState(LockTargetState.SECURED, (error) => {
-      expect(error).toBeFalsy();
-      const { calls } = installation.client.mock;
-      expect(calls.length).toBe(3);
+    await doorLock.setTargetLockState(LockTargetState.SECURED);
 
-      setTimeout(() => { // Wait for setImmediate
-        expect(doorLock.lockService.getCharacteristic(LockCurrentState).value)
-          .toBe(LockTargetState.SECURED);
-        done();
-      }, 100);
+    const { calls } = installation.client.mock;
+    expect(calls.length).toBe(3);
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
     });
+
+    expect(doorLock.lockService.getCharacteristic(LockCurrentState).value).toBe(
+      LockTargetState.SECURED
+    );
   });
 
-  it('sets target lock state to same as current state', (done) => {
-    expect.assertions(2);
-    installation.client = jest.fn();
-    installation.client.mockRejectedValue({
-      errors: [{
-        data: {
-          errorCode: 'VAL_00819',
-        },
-      }],
-    });
-
-    doorLock.setTargetLockState(LockTargetState.SECURED, (error) => {
-      expect(error).toBeFalsy();
-
-      setTimeout(() => { // Wait for setImmediate
-        expect(doorLock.lockService.getCharacteristic(LockCurrentState).value)
-          .toBe(LockTargetState.SECURED);
-        done();
-      }, 100);
-    });
-  });
-
-  it('handles error when setting lock state', (done) => {
+  it('sets target lock state to same as current state', async () => {
     expect.assertions(1);
     installation.client = jest.fn();
     installation.client.mockRejectedValue({
-      errors: [{
-        data: {
-          errorCode: 'VAL_1337',
+      errors: [
+        {
+          data: {
+            errorCode: 'VAL_00819',
+          },
         },
-      }],
+      ],
     });
 
-    doorLock.setTargetLockState(LockTargetState.SECURED, (error) => {
-      expect(error.errors[0].data.errorCode).toBe('VAL_1337');
-      done();
+    await doorLock.setTargetLockState(LockTargetState.SECURED);
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
     });
+
+    expect(doorLock.lockService.getCharacteristic(LockCurrentState).value).toBe(
+      LockTargetState.SECURED
+    );
+  });
+
+  it('handles error when setting lock state', async () => {
+    expect.assertions(1);
+    installation.client = jest.fn();
+    installation.client.mockRejectedValue({
+      errors: [
+        {
+          data: {
+            errorCode: 'VAL_1337',
+          },
+        },
+      ],
+    });
+
+    await expect(doorLock.setTargetLockState(LockTargetState.SECURED)).rejects.toBeTruthy();
   });
 
   it('resolves disabled auto lock state from config', () => {
@@ -203,63 +204,55 @@ describe('DoorLock', () => {
     expect(state).toBe(true);
   });
 
-  it('get current auto lock disabled state', (done) => {
+  it('get current auto lock disabled state', async () => {
     installation.client = jest.fn();
     installation.client.mockResolvedValueOnce({
       installation: {
-        smartLocks: [{
-          configuration: {
-            autoLockEnabled: false,
+        smartLocks: [
+          {
+            configuration: {
+              autoLockEnabled: false,
+            },
           },
-        }],
+        ],
       },
     });
-    doorLock.getAutoLockState((error, value) => {
-      expect(error).toBeNull();
-      expect(value).toBe(false);
-      done();
-    });
+    const value = await doorLock.getAutoLockState();
+    expect(value).toBe(false);
   });
 
-  it('set auto lock switch state', (done) => {
-    expect.assertions(2);
+  it('set auto lock switch state', async () => {
+    expect.assertions(1);
     installation.client = jest.fn();
     installation.client.mockResolvedValueOnce({ something: 'something' });
 
-    doorLock.setAutoLockState(true, (error) => {
-      expect(doorLock.autoLockState).toBe(true);
-      expect(error).toBeNull();
-      done();
-    });
+    await doorLock.setAutoLockState(true);
+    expect(doorLock.autoLockState).toBe(true);
   });
 
-  it('get current audio switch state', (done) => {
+  it('get current audio switch state', async () => {
     installation.client = jest.fn();
     installation.client.mockResolvedValueOnce({
       installation: {
-        smartLocks: [{
-          configuration: {
-            volume: 'LOW',
+        smartLocks: [
+          {
+            configuration: {
+              volume: 'LOW',
+            },
           },
-        }],
+        ],
       },
     });
-    doorLock.getAudioState((error, value) => {
-      expect(error).toBeNull();
-      expect(value).toBe(false); // LOW
-      done();
-    });
+    const value = await doorLock.getAudioState();
+    expect(value).toBe(false); // LOW
   });
 
-  it('set audio switch state on', (done) => {
-    expect.assertions(2);
+  it('set audio switch state on', async () => {
+    expect.assertions(1);
     installation.client = jest.fn();
     installation.client.mockResolvedValueOnce({ something: 'something' });
 
-    doorLock.setAudioState(true, (error) => {
-      expect(doorLock.audioState).toBe(true); // HIGH
-      expect(error).toBeNull();
-      done();
-    });
+    await doorLock.setAudioState(true);
+    expect(doorLock.audioState).toBe(true); // HIGH
   });
 });

--- a/lib/accessories/smartplug.js
+++ b/lib/accessories/smartplug.js
@@ -6,8 +6,9 @@ class SmartPlug extends VerisureAccessory {
     super(...args);
 
     this.model = 'SMARTPLUG';
+    const area = (this.config.device.area || '').trim();
     this.name = VerisureAccessory.getUniqueAccessoryName(
-      `SmartPlug - ${(this.config.device.area || '').trim()}`
+      area ? `SmartPlug - ${area}` : 'SmartPlug'
     );
     this.value = SmartPlug.resolveSwitchState(this.config.currentState);
   }

--- a/lib/accessories/smartplug.js
+++ b/lib/accessories/smartplug.js
@@ -6,7 +6,9 @@ class SmartPlug extends VerisureAccessory {
     super(...args);
 
     this.model = 'SMARTPLUG';
-    this.name = VerisureAccessory.getUniqueAccessoryName(`SmartPlug - ${this.config.device.area}`);
+    this.name = VerisureAccessory.getUniqueAccessoryName(
+      `SmartPlug - ${(this.config.device.area || '').trim()}`
+    );
     this.value = SmartPlug.resolveSwitchState(this.config.currentState);
   }
 
@@ -14,31 +16,29 @@ class SmartPlug extends VerisureAccessory {
     return input === 'ON';
   }
 
-  getSwitchState(callback) {
+  async getSwitchState() {
     this.log('Getting current switch state.');
 
-    this.installation.client(overviewOperation)
-      .then((overview) => overview.installation.smartplugs
-        .find((smartplug) => smartplug.device.deviceLabel === this.serialNumber))
-      .then((smartplug) => {
-        this.value = SmartPlug.resolveSwitchState(smartplug.currentState);
-        callback(null, this.value);
-      })
-      .catch(callback);
+    const overview = await this.installation.client(overviewOperation);
+    const smartplug = overview.installation.smartplugs.find(
+      (sp) => sp.device.deviceLabel === this.serialNumber
+    );
+
+    this.value = SmartPlug.resolveSwitchState(smartplug.currentState);
+    return this.value;
   }
 
-  setSwitchState(value, callback) {
+  async setSwitchState(value) {
     this.log(`Setting switch state to: ${value}`);
 
     this.value = value;
 
-    this.installation.client(smartPlugStateOperation(this.serialNumber, value))
-      // TODO: Poll for result?
-      .then(() => callback(null))
-      .catch((error) => {
-        this.log(`Error setting switch state: ${error.errorMessage}`);
-        callback({ message: error.errorMessage });
-      });
+    try {
+      await this.installation.client(smartPlugStateOperation(this.serialNumber, value));
+    } catch (error) {
+      this.log(`Error setting switch state: ${error.errorMessage}`);
+      throw new Error(error.errorMessage);
+    }
   }
 
   getServices() {
@@ -47,9 +47,10 @@ class SmartPlug extends VerisureAccessory {
     this.service = new Service.Switch(this.name);
     this.service
       .getCharacteristic(Characteristic.On)
-      .on('get', this.getSwitchState.bind(this))
-      .on('set', this.setSwitchState.bind(this))
-      .value = this.value;
+      .onGet(this.getSwitchState.bind(this))
+      .onSet(this.setSwitchState.bind(this));
+
+    this.service.updateCharacteristic(Characteristic.On, this.value);
 
     this.accessoryInformation.setCharacteristic(Characteristic.Model, this.model);
 

--- a/lib/accessories/smartplug.test.js
+++ b/lib/accessories/smartplug.test.js
@@ -1,4 +1,4 @@
-const hap = require('hap-nodejs');
+const hap = require('@homebridge/hap-nodejs');
 
 const SmartPlug = require('./smartplug');
 
@@ -26,7 +26,7 @@ describe('SmartPlug', () => {
     expect(smartPlug.value).toBe(true);
   });
 
-  it('get current switch state', (done) => {
+  it('get current switch state', async () => {
     installation.client = jest.fn();
     installation.client.mockResolvedValueOnce({
       installation: {
@@ -38,23 +38,17 @@ describe('SmartPlug', () => {
         }],
       },
     });
-    smartPlug.getSwitchState((error, value) => {
-      expect(error).toBeNull();
-      expect(value).toBe(false);
-      done();
-    });
+    const value = await smartPlug.getSwitchState();
+    expect(value).toBe(false);
   });
 
-  it('set switch state', (done) => {
-    expect.assertions(2);
+  it('set switch state', async () => {
+    expect.assertions(1);
     installation.client = jest.fn();
     // TODO: Confirm response.
     installation.client.mockResolvedValueOnce({ success: true });
 
-    smartPlug.setSwitchState(true, (error) => {
-      expect(smartPlug.value).toBe(true);
-      expect(error).toBeNull();
-      done();
-    });
+    await smartPlug.setSwitchState(true);
+    expect(smartPlug.value).toBe(true);
   });
 });

--- a/lib/accessories/verisure.js
+++ b/lib/accessories/verisure.js
@@ -23,7 +23,14 @@ class VerisureAccessory {
 
     if (platformConfig && platformConfig.pollInterval) {
       setInterval(() => {
-        this.pollCharacteristics.forEach((characteristic) => characteristic.getValue());
+        this.pollCharacteristics.forEach(async ({ characteristic, getter }) => {
+          try {
+            const value = await getter();
+            characteristic.updateValue(value);
+          } catch (error) {
+            this.log(error.message, 'debug');
+          }
+        });
       }, platformConfig.pollInterval * 1000);
     }
   }
@@ -45,10 +52,12 @@ class VerisureAccessory {
       .then(({ installation: { pollResult: { result } } }) => {
         this.log(`Got "${result}" back from: ${operation.operationName}`);
         if (result === null) {
-          return new Promise((resolve) => setTimeout(
-            () => resolve(this.resolveChangeResult(operation)),
-            200,
-          ));
+          return new Promise((resolve) => {
+            setTimeout(
+              () => resolve(this.resolveChangeResult(operation)),
+              200
+            );
+          });
         }
         return result;
       });

--- a/lib/accessories/verisure.test.js
+++ b/lib/accessories/verisure.test.js
@@ -1,4 +1,4 @@
-const hap = require('hap-nodejs');
+const hap = require('@homebridge/hap-nodejs');
 
 const Verisure = require('./verisure');
 

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -59,7 +59,7 @@ class VerisurePlatform {
     this.verisure = new Verisure(
       this.config.email,
       this.config.password,
-      this.config.cookies,
+      this.config.cookies
     );
   }
 
@@ -103,7 +103,7 @@ class VerisurePlatform {
           this.logger,
           deviceConfig,
           installation,
-          this.config,
+          this.config
         ));
       });
     });
@@ -140,7 +140,7 @@ class VerisurePlatform {
       this.installations.map((installation) => Promise.all([
         installation,
         installation.client(overviewOperation),
-      ])),
+      ]))
     );
 
     try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-verisure",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "Verisure plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "MIT",
   "keywords": [
@@ -23,21 +23,21 @@
     "url": "http://github.com/ptz0n/homebridge-verisure/issues"
   },
   "engines": {
-    "node": ">=12",
-    "homebridge": ">=1.0.0"
+    "node": ">=18",
+    "homebridge": "^1.8.0 || ^2.0.0-beta.0"
   },
   "dependencies": {
     "enquirer": "^2.3.6",
     "verisure": "^5.1.2"
   },
   "devDependencies": {
-    "eslint": "^6.7.2",
-    "eslint-config-airbnb-base": "^14.0.0",
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jest": "^23.1.0",
-    "hap-nodejs": "^0.11.1",
-    "homebridge": "^1.7.0",
-    "jest": "^25.0.0"
+    "eslint": "^8.57.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-jest": "^27.6.0",
+    "@homebridge/hap-nodejs": "^2.0.0",
+    "homebridge": "^2.0.0",
+    "jest": "^29.0.0"
   },
   "jest": {
     "testEnvironment": "node"


### PR DESCRIPTION
Closes #175.

This migrates the plugin to be compatible with Homebridge 2.0 while keeping support for Homebridge 1.8+. Verified in production against Homebridge 2.0.0 (HAP v2.1.4) with a live Verisure installation — alarm, climate sensors and contact sensor all register and update through Apple Home as expected.

The full set of changes is described in the commit message and CHANGELOG. Key points:

* All characteristic handlers migrated to onGet/onSet async API.
* `hap-nodejs` dev dependency replaced with `@homebridge/hap-nodejs ^2.0.0` (package was renamed for Homebridge 2.0).
* Polling loop rewritten since `Characteristic#getValue()` was removed.
* Accessory area names are now trimmed to satisfy HAP 2.x's stricter Name characteristic validation.
* Node.js 18+ and Homebridge 1.8+ are required (BREAKING).

44/44 unit tests pass. CI matrix updated to Node 18/20/22.